### PR TITLE
Clean and extend README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,67 +1,59 @@
 mendeley-rpm
 ============
 
-About
+[mendeley-rpm](Git Repository at: https://github.com/hmaarrfk/mendeley-rpm)
+This is an unofficial package designed for Fedora that packages [Mendeley
+Desktop](https://www.mendeley.com/) freely available from the web.
+
+It attempts to maximize the use of system libraries and to adhere to Fedora
+guidelines.
+
+The only files I wrote were the .spec and a fresh mendeleydesktop executable
+(that essentially does nothing). Therefore I won't bother putting a license on
+my files. The license for the files obtained from Mendeley is included as part
+of this install.
+
+Installation
 ============
 
-This is an unofficial package designed for Fedora that packages
-Mendeley Desktop freely available from the web.
+Easy way
+--------
 
-It attempts to maximize the use of system libraries and to adhere to Fedora guidelines.
+1. Download the latest RPM file for your computer architecture from
+   https://github.com/hmaarrfk/mendeley-rpm/releases
+2. Open a terminal and navigate to the folder which contains the RPM file, for
+   example: `cd ~/Downloads`
+3. Now, install the RPM file, for example with `sudo dnf install
+   mendeleydesktop-VERSION.ARCHITECTURE.rpm` (where you have to replace
+   VERSION and ARCHITECTURE).
 
-The only files I wrote were the .spec and a fresh mendeleydesktop executable (that essentially does nothing). Therefore I won't bother putting a license on my files. The license for the files obtained from Mendeley is included as part of this install.
+Hard way: Build the RPM yourself
+--------------------------------
 
-How to install
-============
-Easy way: https://github.com/hmaarrfk/mendeley-rpm/releases
+1. Clone: `git clone https://github.com/hmaarrfk/mendeley-rpm.git`.
+2. `make`.
+3. Run `mock` with the generated `srpm`.
 
-Hard way: Build the RPM yourself.
-1. Clone
-2. `make`
-3. Run `mock` with the generated `srpm`
-
-
-~~
-You need to run this line in a terminal so that qt5 finds the right plugin, for Mendeley 1.17 and above:
-```sh
-sudo ln -sf /usr/lib64/qt5/plugins/platforms/ /usr/bin/platforms
-```
-~~
-~~Easy way: https://copr.fedoraproject.org/coprs/hmaarrfk/mendeleydesktop/~~
-We cannot host this on COPR since it is not open source software.
-
-Licensing issues
-============
-Download the "source" (really a binary from mendeley) and run the ./package-mendeley-rpm.sh script
-Then use mock on the source rpm.
+Wish official support
+=====================
 
 The issue of having an RPM has been raised to Mendeley in the past:
-General Linux 2012
-http://support.mendeley.com/customer/portal/questions/567256-linux-make-a-linux-installer
-Gentoo 2012
-http://support.mendeley.com/customer/portal/questions/199131-on-distribution-policy-and-download-link
-Fedora 2013
-http://support.mendeley.com/customer/portal/questions/758741-packaging-for-fedora
 
+* [General Linux
+  2012](http://support.mendeley.com/customer/portal/questions/567256-linux-make-a-linux-installer)
+* [Gentoo
+  2012](http://support.mendeley.com/customer/portal/questions/199131-on-distribution-policy-and-download-link)
+* [Fedora
+  2013](http://support.mendeley.com/customer/portal/questions/758741-packaging-for-fedora)
 
-The first version was written by
-Mark Harfouche
-2013.01.21
+Collaborators
+=============
 
-A few collaborators helped along the way
-
-Chris Fallin
-
-Filipe Manco
-
-Git Repository at:
-https://github.com/hmaarrfk/mendeley-rpm
-
-Get ther tarball from
-mendeley.com
+The first version was written by Mark Harfouche (2013.01.21). A few
+collaborators helped along the way: Chris Fallin, Filipe Manco.
 
 Development Notes
-============
+=================
 
 It might be instructive to look at what was done by the Gentoo community.
 http://gentoo-overlays.zugaina.org/funtoo/sci-misc.html.en#mendeleydesktop
@@ -72,17 +64,23 @@ I always feel like installing into /opt is a hack.
 Then again, they are not like packaging noobs like we are :D.
 
 Packaging Situation
-============
-At one point in time, this package was hosted on COPR. This broke their guidelines so I had to remove it.
+===================
 
-I was trying to upload it to rpmfusion but hit a small snag that I don't particularly have time to solve.
-If you want to, you can merge Dominik's spec file with this one, add both of you to the author list (or at least credit Dominik for his good work) and revive the issue on the bug request below.
+At one point in time, this package was hosted on COPR. This broke their
+guidelines so I had to remove it.
+
+I was trying to upload it to rpmfusion but hit a small snag that I don't
+particularly have time to solve. If you want to, you can merge Dominik's spec
+file with this one, add both of you to the author list (or at least credit
+Dominik for his good work) and revive the issue on the bug request below.
 
 https://bugzilla.rpmfusion.org/show_bug.cgi?id=4041
 
-Since Mendeley doesn't update too often, manually downloading the RPM didn't seem like a bad solution.
+Since Mendeley doesn't update too often, manually downloading the RPM didn't
+seem like a bad solution.
 
 Other ways to obtain Mendeley
-============
+=============================
+
 AppImage: (Seems a little out of date though)
 https://bintray.com/probono/AppImages/Mendeley_Desktop/


### PR DESCRIPTION
* Clean markdown-code.
* Remove striked/canceled instruction.
* Elaborate the easy way of installation.
* Re-arrange texts.
* Use 78 characters maximum when possible.